### PR TITLE
Add a package setting in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(name='qha',
           'matplotlib',
           'seaborn',
       ],
+      packages=[
+          'qha'
+      ],
       scripts=[
           'scripts/qha',
           'scripts/qha-convert'


### PR DESCRIPTION
Adding a package setting in `setup.py`, otherwise, python wouldn't index this package.