### PR TITLE
Using dH/dT to calculate Cp

### DIFF
--- a/qha/calculator/tp_adapter.py
+++ b/qha/calculator/tp_adapter.py
@@ -126,10 +126,8 @@ class TemperaturePressureFieldAdapter:
     @units.wraps(units.Ryd / units.kelvin, None)
     def pressure_specific_heat_capacities(self):
         return pressure_specific_heat_capacity(
-            self.volume_specific_heat_capacities.magnitude,
-            self.thermal_expansion_coefficients.magnitude,
-            self.gruneisen_parameters.magnitude,
-            self.temperature_array.magnitude
+            self.temperature_array.magnitude,
+            self.entropies.magnitude
         )
 
     @LazyProperty

--- a/qha/thermodynamics.py
+++ b/qha/thermodynamics.py
@@ -167,7 +167,7 @@ def bulk_modulus_derivative(p_vector: Vector, bt_tp: Matrix) -> Matrix:
     return calculate_derivatives(p_vector, bt_tp.T).T
 
 
-def pressure_specific_heat_capacity(cv_tp: Matrix, alpha_tp: Matrix, gamma_tp: Matrix, ts: Vector) -> Matrix:
+def pressure_specific_heat_capacity(ts: Vector, h_tp: Matrix) -> Matrix:
     """
     Equation used: :math:`Cp = Bt \\left ( 1 + \\alpha \\gamma T \\right )`
 
@@ -177,7 +177,7 @@ def pressure_specific_heat_capacity(cv_tp: Matrix, alpha_tp: Matrix, gamma_tp: M
     :param ts: temperature vector
     :return: pressure specific heat capacity, :math:`Cp(T,P)`
     """
-    return cv_tp * (1.0 + alpha_tp * gamma_tp * ts[:, None])
+    return calculate_derivatives(ts, h_tp)
 
 
 def volume_specific_heat_capacity(ts: Vector, internal_energies: Matrix) -> Matrix:


### PR DESCRIPTION
Fixes strange behavior when calculating Cp

## Proposed Changes

  - Use dH/dT to bypass the usage of gamma
