### PR TITLE
Solve issue #58 brutally

### DIFF
--- a/qha/out.py
+++ b/qha/out.py
@@ -74,7 +74,6 @@ def make_ending_string(time_elapsed) -> str:
     return textwrap.dedent("""\
         ------------------------------------------------------------
         Total elapsed time is: {0:8.2f} seconds
-        All the files are saved in the './results/' directory.
         Thanks for using QHA code, have a nice one :)
         ============================================================
         """.format(time_elapsed))


### PR DESCRIPTION
Fixes #58 

## Proposed Changes

There will be no `All the files are saved in the './results/' directory.` printed to `output.txt` since it is useless as pointed out in #58.