### PR TITLE
Fix splitting in `FromQEOutput.read_frequency_file`

### DIFF
--- a/qha/basic_io/input_maker.py
+++ b/qha/basic_io/input_maker.py
@@ -189,7 +189,11 @@ class FromQEOutput:
             x = np.array([])
             for _ in range(quotient):
                 line = next(gen)  # Start a new line
-                x = np.hstack((x, line.split()))
+                # Sometimes QE prints negative numbers that coalesce with the previous one,
+                # so we need to split not only spaces but also minus signs
+                # Regex from https://stackoverflow.com/a/30858977/3260253
+                freqs = list(filter(lambda s: s, re.split(r'\s+|(?<!\s)(?=-)', line)))
+                x = np.hstack((x, freqs))
 
             frequencies.append(x)
 


### PR DESCRIPTION
Sometimes we have imaginary frequencies for our materials. And QE prints them out in negative numbers. If the number is too long, it may coalesce with the previous one, like below:

```
           -0.222230 -0.355470  0.344040
-1447.3713-1187.8571  -80.3199  329.8292  833.3836 1105.8035
```

So this will cause `read_frequency_file` not be able to read the frequencies correctly. In this change I want to make it split either at a minus sign or at a space.
