### PR TITLE
[codex] Fix QE matdyn frequency token parsing

### DIFF
--- a/src/qha/basic_io/input_maker.py
+++ b/src/qha/basic_io/input_maker.py
@@ -28,6 +28,12 @@ except ImportError:
 # ===================== What can be exported? =====================
 __all__ = ["FromQEOutput"]
 
+_NUMBER = re.compile(r"[+-]?(?:(?:\d+\.\d*)|(?:\.\d+)|(?:\d+))(?:[Ee][+-]?\d+)?")
+
+
+def _numbers_from_line(line: str) -> list[str]:  # See https://github.com/MineralsCloud/qha/issues/86
+    return _NUMBER.findall(line)
+
 
 class FromQEOutput:
     """
@@ -204,10 +210,7 @@ class FromQEOutput:
             x = np.array([])
             for _ in range(quotient):
                 line = next(gen)  # Start a new line
-                # Sometimes QE prints negative numbers that coalesce with the previous one,
-                # so we need to split not only spaces but also minus signs
-                # Regex from https://stackoverflow.com/a/30858977/3260253
-                freqs = list(filter(lambda s: s, re.split(r"\s+|(?<!\s)(?=-)", line)))
+                freqs = _numbers_from_line(line)
                 x = np.hstack((x, freqs))
 
             frequencies.append(x)

--- a/tests/test_input_maker.py
+++ b/tests/test_input_maker.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import pathlib
+import tempfile
+import unittest
+
+import numpy as np
+
+from qha.basic_io.input_maker import FromQEOutput
+
+
+class TestFromQEOutput(unittest.TestCase):
+    def test_read_frequency_file_splits_adjacent_negative_frequencies(self):
+        content = """\
+&plot nbnd=   6, nks=   1 /
+            0.300000  0.291188  0.276701
+-2471.6424-2400.9590-1460.5687-1267.3818  157.7216  181.1466
+"""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "matdyn.freq"
+            path.write_text(content)
+
+            q_coordinates, frequencies = FromQEOutput.read_frequency_file(str(path))
+
+        np.testing.assert_array_equal(q_coordinates, [[0.3, 0.291188, 0.276701]])
+        np.testing.assert_array_equal(
+            frequencies,
+            [[-2471.6424, -2400.959, -1460.5687, -1267.3818, 157.7216, 181.1466]],
+        )
+
+    def test_read_frequency_file_preserves_exponent_signs(self):
+        content = """\
+&plot nbnd=   6, nks=   1 /
+            0.300000  0.291188  0.276701
+ 1.0000E-03-2.5000E+02  .3000  4.  +5.0000 -6
+"""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = pathlib.Path(tmpdir) / "matdyn.freq"
+            path.write_text(content)
+
+            _, frequencies = FromQEOutput.read_frequency_file(str(path))
+
+        np.testing.assert_array_equal(
+            frequencies, [[0.001, -250, 0.3, 4, 5, -6]]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #86 by parsing QE `matdyn.x` frequency rows as numeric tokens instead of splitting on whitespace and adjacent minus signs.

## Root Cause

The previous parser used `re.split(r"\s+|(?<!\s)(?=-)", line)` to handle merged negative frequencies such as `-2471.6424-2400.9590`. That delimiter-based approach can split valid scientific notation at exponent signs, for example `1.0000E-03`.

## Changes

- Add a numeric token regex for frequency-line parsing.
- Replace delimiter splitting in `FromQEOutput.read_frequency_file` with number extraction.
- Add regression tests for merged negative frequencies and exponent signs.

## Validation

- `uv run python -m unittest tests.test_input_maker`